### PR TITLE
Update 14 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.Mqtt.nuspec
+++ b/MakoIoT.Device.Services.Mqtt.nuspec
@@ -17,19 +17,19 @@
     <description>MQTT library for message bus of MAKO-IoT</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot mqtt message bus</tags>
     <dependencies>
-	    <dependency id="MakoIoT.Device.Services.DependencyInjection" version="1.0.3"  />
-	    <dependency id="MakoIoT.Device.Services.Interface" version="1.0.3"  />
-	    <dependency id="MakoIoT.Device.Utilities.String" version="1.0.2"  />
-	    <dependency id="nanoFramework.CoreLibrary" version="1.12.0"  />
-	    <dependency id="nanoFramework.Logging" version="1.1.25"  />
-	    <dependency id="nanoFramework.M2Mqtt" version="5.1.27"  />
-	    <dependency id="nanoFramework.Runtime.Events" version="1.11.1"  />
-	    <dependency id="nanoFramework.Runtime.Native" version="1.5.4"  />
-	    <dependency id="nanoFramework.System.Collections" version="1.4.0"  />
-	    <dependency id="nanoFramework.System.IO.Streams" version="1.1.15"  />
-	    <dependency id="nanoFramework.System.Net" version="1.10.24"  />
-	    <dependency id="nanoFramework.System.Text" version="1.2.7"  />
-	    <dependency id="nanoFramework.System.Threading" version="1.1.8"  />
+      <dependency id="MakoIoT.Device.Services.DependencyInjection" version="1.0.17.52441" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.17.36444" />
+      <dependency id="MakoIoT.Device.Utilities.String" version="1.0.15.64242" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.Logging" version="1.1.63" />
+      <dependency id="nanoFramework.M2Mqtt" version="5.1.75" />
+      <dependency id="nanoFramework.Runtime.Events" version="1.11.6" />
+      <dependency id="nanoFramework.Runtime.Native" version="1.6.6" />
+      <dependency id="nanoFramework.System.Collections" version="1.5.18" />
+      <dependency id="nanoFramework.System.IO.Streams" version="1.1.38" />
+      <dependency id="nanoFramework.System.Net" version="1.10.52" />
+      <dependency id="nanoFramework.System.Text" version="1.2.37" />
+      <dependency id="nanoFramework.System.Threading" version="1.1.19" />
     </dependencies>
   </metadata>
   <files>

--- a/src/MakoIoT.Device.Services.Mqtt/MakoIoT.Device.Services.Mqtt.nfproj
+++ b/src/MakoIoT.Device.Services.Mqtt/MakoIoT.Device.Services.Mqtt.nfproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\Nerdbank.GitVersioning.3.5.119\build\Nerdbank.GitVersioning.props" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.3.5.119\build\Nerdbank.GitVersioning.props')" />
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
   </PropertyGroup>
@@ -23,44 +24,57 @@
     <Compile Include="MqttCommunicationService.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="MakoIoT.Device.Services.DependencyInjection">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.DependencyInjection.1.0.3.25020\lib\MakoIoT.Device.Services.DependencyInjection.dll</HintPath>
+    <Reference Include="MakoIoT.Device.Services.DependencyInjection, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\MakoIoT.Device.Services.DependencyInjection.1.0.17.52441\lib\MakoIoT.Device.Services.DependencyInjection.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="MakoIoT.Device.Services.Interface">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.3.26226\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+    <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.17.36444\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="MakoIoT.Device.Utilities.String">
-      <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.2.14320\lib\MakoIoT.Device.Utilities.String.dll</HintPath>
+    <Reference Include="MakoIoT.Device.Utilities.String, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.15.64242\lib\MakoIoT.Device.Utilities.String.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="mscorlib">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.12.0\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Logging">
-      <HintPath>..\..\packages\nanoFramework.Logging.1.1.25\lib\nanoFramework.Logging.dll</HintPath>
+    <Reference Include="nanoFramework.Logging, Version=1.1.63.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Logging.1.1.63\lib\nanoFramework.Logging.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.M2Mqtt">
-      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.27\lib\nanoFramework.M2Mqtt.dll</HintPath>
+    <Reference Include="nanoFramework.M2Mqtt, Version=5.1.75.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.75\lib\nanoFramework.M2Mqtt.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.1\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.6\lib\nanoFramework.Runtime.Events.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Native">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Native.1.5.4\lib\nanoFramework.Runtime.Native.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Native, Version=1.6.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Native.1.6.6\lib\nanoFramework.Runtime.Native.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.4.0\lib\nanoFramework.System.Collections.dll</HintPath>
+    <Reference Include="nanoFramework.System.Collections, Version=1.5.18.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.18\lib\nanoFramework.System.Collections.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.System.Text">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.2.7\lib\nanoFramework.System.Text.dll</HintPath>
+    <Reference Include="nanoFramework.System.Text, Version=1.2.37.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.2.37\lib\nanoFramework.System.Text.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.IO.Streams">
-      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.15\lib\System.IO.Streams.dll</HintPath>
+    <Reference Include="System.IO.Streams, Version=1.1.38.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.38\lib\System.IO.Streams.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.10.24\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.10.52.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.10.52\lib\System.Net.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Threading">
-      <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.8\lib\System.Threading.dll</HintPath>
+    <Reference Include="System.Threading, Version=1.1.19.33722, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.19\lib\System.Threading.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -72,11 +86,12 @@
       <ProjectConfigurationsDeclaredAsItems />
     </ProjectCapabilities>
   </ProjectExtensions>
-  <Import Project="..\..\packages\Nerdbank.GitVersioning.3.5.113\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.3.5.113\build\Nerdbank.GitVersioning.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.5.113\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.5.113\build\Nerdbank.GitVersioning.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.5.119\build\Nerdbank.GitVersioning.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.5.119\build\Nerdbank.GitVersioning.props'))" />
+    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.5.119\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.5.119\build\Nerdbank.GitVersioning.targets'))" />
   </Target>
+  <Import Project="..\..\packages\Nerdbank.GitVersioning.3.5.119\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.3.5.119\build\Nerdbank.GitVersioning.targets')" />
 </Project>

--- a/src/MakoIoT.Device.Services.Mqtt/packages.config
+++ b/src/MakoIoT.Device.Services.Mqtt/packages.config
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.DependencyInjection" version="1.0.3.25020" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.3.26226" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Utilities.String" version="1.0.2.14320" targetFramework="netnano1.0" />
-  <package id="nanoFramework.CoreLibrary" version="1.12.0" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Logging" version="1.1.25" targetFramework="netnano1.0" />
-  <package id="nanoFramework.M2Mqtt" version="5.1.27" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Runtime.Events" version="1.11.1" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Runtime.Native" version="1.5.4" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Collections" version="1.4.0" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.IO.Streams" version="1.1.15" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.10.24" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Text" version="1.2.7" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Threading" version="1.1.8" targetFramework="netnano1.0" />
-  <package id="Nerdbank.GitVersioning" version="3.5.113" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="MakoIoT.Device.Services.DependencyInjection" version="1.0.17.52441" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.17.36444" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Utilities.String" version="1.0.15.64242" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Logging" version="1.1.63" targetFramework="netnano1.0" />
+  <package id="nanoFramework.M2Mqtt" version="5.1.75" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.6" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Native" version="1.6.6" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Collections" version="1.5.18" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.38" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.10.52" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.2.37" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Threading" version="1.1.19" targetFramework="netnano1.0" />
+  <package id="Nerdbank.GitVersioning" version="3.5.119" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.DependencyInjection from 1.0.3.25020 to 1.0.17.52441</br>Bumps MakoIoT.Device.Services.Interface from 1.0.3.26226 to 1.0.17.36444</br>Bumps MakoIoT.Device.Utilities.String from 1.0.2.14320 to 1.0.15.64242</br>Bumps nanoFramework.CoreLibrary from 1.12.0 to 1.14.2</br>Bumps nanoFramework.Logging from 1.1.25 to 1.1.63</br>Bumps nanoFramework.M2Mqtt from 5.1.27 to 5.1.75</br>Bumps nanoFramework.Runtime.Events from 1.11.1 to 1.11.6</br>Bumps nanoFramework.Runtime.Native from 1.5.4 to 1.6.6</br>Bumps nanoFramework.System.Collections from 1.4.0 to 1.5.18</br>Bumps nanoFramework.System.IO.Streams from 1.1.15 to 1.1.38</br>Bumps nanoFramework.System.Net from 1.10.24 to 1.10.52</br>Bumps nanoFramework.System.Text from 1.2.7 to 1.2.37</br>Bumps nanoFramework.System.Threading from 1.1.8 to 1.1.19</br>Bumps Nerdbank.GitVersioning from 3.5.113 to 3.5.119</br>
[version update]

### :warning: This is an automated update. :warning:
