### PR TITLE
Update 2 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.Mqtt.nuspec
+++ b/MakoIoT.Device.Services.Mqtt.nuspec
@@ -17,10 +17,10 @@
     <description>MQTT library for message bus of MAKO-IoT</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot mqtt message bus</tags>
     <dependencies>
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.40.57355" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.41.25178" />
       <dependency id="MakoIoT.Device.Utilities.String" version="1.0.33.52014" />
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
-      <dependency id="nanoFramework.Logging" version="1.1.74" />
+      <dependency id="nanoFramework.Logging" version="1.1.76" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.3" />
       <dependency id="nanoFramework.M2Mqtt" version="5.1.107" />
       <dependency id="nanoFramework.Runtime.Events" version="1.11.15" />

--- a/src/MakoIoT.Device.Services.Mqtt/MakoIoT.Device.Services.Mqtt.nfproj
+++ b/src/MakoIoT.Device.Services.Mqtt/MakoIoT.Device.Services.Mqtt.nfproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.40.57355\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.41.25178\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.String, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
@@ -41,8 +41,8 @@
       <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.3\lib\nanoFramework.DependencyInjection.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Logging, Version=1.1.74.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Logging.1.1.74\lib\nanoFramework.Logging.dll</HintPath>
+    <Reference Include="nanoFramework.Logging, Version=1.1.76.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Logging.1.1.76\lib\nanoFramework.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.M2Mqtt, Version=5.1.107.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/src/MakoIoT.Device.Services.Mqtt/packages.config
+++ b/src/MakoIoT.Device.Services.Mqtt/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.40.57355" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.41.25178" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.33.52014" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Logging" version="1.1.74" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Logging" version="1.1.76" targetFramework="netnano1.0" />
   <package id="nanoFramework.M2Mqtt" version="5.1.107" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.15" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Native" version="1.6.12" targetFramework="netnanoframework10" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Interface from 1.0.40.57355 to 1.0.41.25178</br>Bumps nanoFramework.Logging from 1.1.74 to 1.1.76</br>
[version update]

### :warning: This is an automated update. :warning:
