### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.Mqtt.nuspec
+++ b/MakoIoT.Device.Services.Mqtt.nuspec
@@ -21,7 +21,7 @@
       <dependency id="MakoIoT.Device.Utilities.String" version="1.0.33.52014" />
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.3" />
-      <dependency id="nanoFramework.M2Mqtt" version="5.1.123" />
+      <dependency id="nanoFramework.M2Mqtt" version="5.1.126" />
       <dependency id="nanoFramework.Runtime.Events" version="1.11.15" />
       <dependency id="nanoFramework.Runtime.Native" version="1.6.12" />
       <dependency id="nanoFramework.System.Collections" version="1.5.31" />

--- a/src/MakoIoT.Device.Services.Mqtt/MakoIoT.Device.Services.Mqtt.nfproj
+++ b/src/MakoIoT.Device.Services.Mqtt/MakoIoT.Device.Services.Mqtt.nfproj
@@ -41,12 +41,12 @@
       <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.3\lib\nanoFramework.DependencyInjection.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.M2Mqtt, Version=5.1.123.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.123\lib\nanoFramework.M2Mqtt.dll</HintPath>
+    <Reference Include="nanoFramework.M2Mqtt, Version=5.1.126.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.126\lib\nanoFramework.M2Mqtt.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.M2Mqtt.Core, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.123\lib\nanoFramework.M2Mqtt.Core.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.126\lib\nanoFramework.M2Mqtt.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.11.15.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/src/MakoIoT.Device.Services.Mqtt/packages.config
+++ b/src/MakoIoT.Device.Services.Mqtt/packages.config
@@ -4,7 +4,7 @@
   <package id="MakoIoT.Device.Utilities.String" version="1.0.33.52014" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
-  <package id="nanoFramework.M2Mqtt" version="5.1.123" targetFramework="netnano1.0" />
+  <package id="nanoFramework.M2Mqtt" version="5.1.126" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.15" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Native" version="1.6.12" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnanoframework10" />


### PR DESCRIPTION
Bumps nanoFramework.M2Mqtt from 5.1.123 to 5.1.126</br>
[version update]

### :warning: This is an automated update. :warning:
