### PR TITLE
Update 8 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.Mqtt.nuspec
+++ b/MakoIoT.Device.Services.Mqtt.nuspec
@@ -17,16 +17,16 @@
     <description>MQTT library for message bus of MAKO-IoT</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot mqtt message bus</tags>
     <dependencies>
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.50.35966" />
-      <dependency id="MakoIoT.Device.Utilities.String" version="1.0.39.56355" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.52.50912" />
+      <dependency id="MakoIoT.Device.Utilities.String" version="1.0.40.2867" />
       <dependency id="nanoFramework.CoreLibrary" version="1.17.1" />
-      <dependency id="nanoFramework.DependencyInjection" version="1.1.25" />
-      <dependency id="nanoFramework.M2Mqtt" version="5.1.180" />
-      <dependency id="nanoFramework.Runtime.Events" version="1.11.29" />
-      <dependency id="nanoFramework.Runtime.Native" version="1.7.8" />
-      <dependency id="nanoFramework.System.Collections" version="1.5.59" />
+      <dependency id="nanoFramework.DependencyInjection" version="1.1.29" />
+      <dependency id="nanoFramework.M2Mqtt" version="5.1.183" />
+      <dependency id="nanoFramework.Runtime.Events" version="1.11.30" />
+      <dependency id="nanoFramework.Runtime.Native" version="1.7.9" />
+      <dependency id="nanoFramework.System.Collections" version="1.5.62" />
       <dependency id="nanoFramework.System.IO.Streams" version="1.1.88" />
-      <dependency id="nanoFramework.System.Net" version="1.11.30" />
+      <dependency id="nanoFramework.System.Net" version="1.11.31" />
       <dependency id="nanoFramework.System.Text" version="1.3.29" />
       <dependency id="nanoFramework.System.Threading" version="1.1.46" />
     </dependencies>

--- a/src/MakoIoT.Device.Services.Mqtt/MakoIoT.Device.Services.Mqtt.nfproj
+++ b/src/MakoIoT.Device.Services.Mqtt/MakoIoT.Device.Services.Mqtt.nfproj
@@ -27,31 +27,31 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.50.35966\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.52.50912\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.String, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.39.56355\lib\MakoIoT.Device.Utilities.String.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.40.2867\lib\MakoIoT.Device.Utilities.String.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib, Version=1.17.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.1\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.25.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.25\lib\nanoFramework.DependencyInjection.dll</HintPath>
+    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.29\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.M2Mqtt, Version=5.1.180.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.180\lib\nanoFramework.M2Mqtt.dll</HintPath>
+    <Reference Include="nanoFramework.M2Mqtt, Version=5.1.183.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.183\lib\nanoFramework.M2Mqtt.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.M2Mqtt.Core, Version=5.1.180.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.180\lib\nanoFramework.M2Mqtt.Core.dll</HintPath>
+    <Reference Include="nanoFramework.M2Mqtt.Core, Version=5.1.183.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.183\lib\nanoFramework.M2Mqtt.Core.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.29\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.30.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.30\lib\nanoFramework.Runtime.Events.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Native, Version=1.7.8.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Native.1.7.8\lib\nanoFramework.Runtime.Native.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Native, Version=1.7.9.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Native.1.7.9\lib\nanoFramework.Runtime.Native.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections, Version=1.5.59.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.59\lib\nanoFramework.System.Collections.dll</HintPath>
+    <Reference Include="nanoFramework.System.Collections, Version=1.5.62.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.62\lib\nanoFramework.System.Collections.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.System.Text, Version=1.3.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Text.1.3.29\lib\nanoFramework.System.Text.dll</HintPath>
@@ -59,8 +59,8 @@
     <Reference Include="System.IO.Streams, Version=1.1.88.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.88\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net, Version=1.11.30.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.30\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.11.31.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.31\lib\System.Net.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.46.1709, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.46\lib\System.Threading.dll</HintPath>

--- a/src/MakoIoT.Device.Services.Mqtt/packages.config
+++ b/src/MakoIoT.Device.Services.Mqtt/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.50.35966" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Utilities.String" version="1.0.39.56355" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.52.50912" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Utilities.String" version="1.0.40.2867" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.17.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.DependencyInjection" version="1.1.25" targetFramework="netnano1.0" />
-  <package id="nanoFramework.M2Mqtt" version="5.1.180" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Runtime.Events" version="1.11.29" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Runtime.Native" version="1.7.8" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Collections" version="1.5.59" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.DependencyInjection" version="1.1.29" targetFramework="netnano1.0" />
+  <package id="nanoFramework.M2Mqtt" version="5.1.183" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.30" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Native" version="1.7.9" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Collections" version="1.5.62" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.88" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.11.30" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.11.31" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.3.29" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.46" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.7.115" targetFramework="netnano1.0" developmentDependency="true" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Interface from 1.0.50.35966 to 1.0.52.50912</br>Bumps MakoIoT.Device.Utilities.String from 1.0.39.56355 to 1.0.40.2867</br>Bumps nanoFramework.DependencyInjection from 1.1.25 to 1.1.29</br>Bumps nanoFramework.M2Mqtt from 5.1.180 to 5.1.183</br>Bumps nanoFramework.Runtime.Events from 1.11.29 to 1.11.30</br>Bumps nanoFramework.Runtime.Native from 1.7.8 to 1.7.9</br>Bumps nanoFramework.System.Collections from 1.5.59 to 1.5.62</br>Bumps nanoFramework.System.Net from 1.11.30 to 1.11.31</br>
[version update]

### :warning: This is an automated update. :warning:
