### PR TITLE
Update 3 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.Mqtt.nuspec
+++ b/MakoIoT.Device.Services.Mqtt.nuspec
@@ -21,12 +21,12 @@
       <dependency id="MakoIoT.Device.Utilities.String" version="1.0.40.2867" />
       <dependency id="nanoFramework.CoreLibrary" version="1.17.1" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.29" />
-      <dependency id="nanoFramework.M2Mqtt" version="5.1.185" />
+      <dependency id="nanoFramework.M2Mqtt" version="5.1.187" />
       <dependency id="nanoFramework.Runtime.Events" version="1.11.30" />
       <dependency id="nanoFramework.Runtime.Native" version="1.7.9" />
       <dependency id="nanoFramework.System.Collections" version="1.5.62" />
-      <dependency id="nanoFramework.System.IO.Streams" version="1.1.88" />
-      <dependency id="nanoFramework.System.Net" version="1.11.32" />
+      <dependency id="nanoFramework.System.IO.Streams" version="1.1.89" />
+      <dependency id="nanoFramework.System.Net" version="1.11.34" />
       <dependency id="nanoFramework.System.Text" version="1.3.29" />
       <dependency id="nanoFramework.System.Threading" version="1.1.49" />
     </dependencies>

--- a/src/MakoIoT.Device.Services.Mqtt/MakoIoT.Device.Services.Mqtt.nfproj
+++ b/src/MakoIoT.Device.Services.Mqtt/MakoIoT.Device.Services.Mqtt.nfproj
@@ -38,11 +38,11 @@
     <Reference Include="nanoFramework.DependencyInjection, Version=1.1.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.29\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.M2Mqtt, Version=5.1.185.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.185\lib\nanoFramework.M2Mqtt.dll</HintPath>
+    <Reference Include="nanoFramework.M2Mqtt, Version=5.1.187.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.187\lib\nanoFramework.M2Mqtt.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.M2Mqtt.Core, Version=5.1.185.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.185\lib\nanoFramework.M2Mqtt.Core.dll</HintPath>
+    <Reference Include="nanoFramework.M2Mqtt.Core, Version=5.1.187.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.187\lib\nanoFramework.M2Mqtt.Core.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.11.30.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.30\lib\nanoFramework.Runtime.Events.dll</HintPath>
@@ -56,11 +56,11 @@
     <Reference Include="nanoFramework.System.Text, Version=1.3.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Text.1.3.29\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Streams, Version=1.1.88.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.88\lib\System.IO.Streams.dll</HintPath>
+    <Reference Include="System.IO.Streams, Version=1.1.89.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.89\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net, Version=1.11.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.32\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.11.34.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.34\lib\System.Net.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.49.41415, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.49\lib\System.Threading.dll</HintPath>

--- a/src/MakoIoT.Device.Services.Mqtt/packages.config
+++ b/src/MakoIoT.Device.Services.Mqtt/packages.config
@@ -4,12 +4,12 @@
   <package id="MakoIoT.Device.Utilities.String" version="1.0.40.2867" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.17.1" targetFramework="netnanoframework10" />
   <package id="nanoFramework.DependencyInjection" version="1.1.29" targetFramework="netnano1.0" />
-  <package id="nanoFramework.M2Mqtt" version="5.1.185" targetFramework="netnano1.0" />
+  <package id="nanoFramework.M2Mqtt" version="5.1.187" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.30" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Native" version="1.7.9" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Collections" version="1.5.62" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.IO.Streams" version="1.1.88" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.11.32" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.89" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.11.34" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.3.29" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.49" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.7.115" targetFramework="netnano1.0" developmentDependency="true" />


### PR DESCRIPTION
Bumps nanoFramework.M2Mqtt from 5.1.185 to 5.1.187</br>Bumps nanoFramework.System.IO.Streams from 1.1.88 to 1.1.89</br>Bumps nanoFramework.System.Net from 1.11.32 to 1.11.34</br>
[version update]

### :warning: This is an automated update. :warning:
