### PR TITLE
Update 10 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.Mqtt.nuspec
+++ b/MakoIoT.Device.Services.Mqtt.nuspec
@@ -19,16 +19,16 @@
     <dependencies>
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.53.21413" />
       <dependency id="MakoIoT.Device.Utilities.String" version="1.0.40.2867" />
-      <dependency id="nanoFramework.CoreLibrary" version="1.17.1" />
-      <dependency id="nanoFramework.DependencyInjection" version="1.1.29" />
-      <dependency id="nanoFramework.M2Mqtt" version="5.1.187" />
-      <dependency id="nanoFramework.Runtime.Events" version="1.11.30" />
-      <dependency id="nanoFramework.Runtime.Native" version="1.7.9" />
-      <dependency id="nanoFramework.System.Collections" version="1.5.62" />
-      <dependency id="nanoFramework.System.IO.Streams" version="1.1.89" />
-      <dependency id="nanoFramework.System.Net" version="1.11.34" />
-      <dependency id="nanoFramework.System.Text" version="1.3.29" />
-      <dependency id="nanoFramework.System.Threading" version="1.1.49" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.17.7" />
+      <dependency id="nanoFramework.DependencyInjection" version="1.1.30" />
+      <dependency id="nanoFramework.M2Mqtt" version="5.1.192" />
+      <dependency id="nanoFramework.Runtime.Events" version="1.11.31" />
+      <dependency id="nanoFramework.Runtime.Native" version="1.7.10" />
+      <dependency id="nanoFramework.System.Collections" version="1.5.63" />
+      <dependency id="nanoFramework.System.IO.Streams" version="1.1.91" />
+      <dependency id="nanoFramework.System.Net" version="1.11.37" />
+      <dependency id="nanoFramework.System.Text" version="1.3.36" />
+      <dependency id="nanoFramework.System.Threading" version="1.1.50" />
     </dependencies>
   </metadata>
   <files>

--- a/src/MakoIoT.Device.Services.Mqtt/MakoIoT.Device.Services.Mqtt.nfproj
+++ b/src/MakoIoT.Device.Services.Mqtt/MakoIoT.Device.Services.Mqtt.nfproj
@@ -32,38 +32,38 @@
     <Reference Include="MakoIoT.Device.Utilities.String, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.40.2867\lib\MakoIoT.Device.Utilities.String.dll</HintPath>
     </Reference>
-    <Reference Include="mscorlib, Version=1.17.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.1\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.17.7.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.7\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.29\lib\nanoFramework.DependencyInjection.dll</HintPath>
+    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.30.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.30\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.M2Mqtt, Version=5.1.187.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.187\lib\nanoFramework.M2Mqtt.dll</HintPath>
+    <Reference Include="nanoFramework.M2Mqtt, Version=5.1.192.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.192\lib\nanoFramework.M2Mqtt.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.M2Mqtt.Core, Version=5.1.187.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.187\lib\nanoFramework.M2Mqtt.Core.dll</HintPath>
+    <Reference Include="nanoFramework.M2Mqtt.Core, Version=5.1.192.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.192\lib\nanoFramework.M2Mqtt.Core.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.30.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.30\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.31.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.31\lib\nanoFramework.Runtime.Events.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Native, Version=1.7.9.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Native.1.7.9\lib\nanoFramework.Runtime.Native.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Native, Version=1.7.10.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Native.1.7.10\lib\nanoFramework.Runtime.Native.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections, Version=1.5.62.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.62\lib\nanoFramework.System.Collections.dll</HintPath>
+    <Reference Include="nanoFramework.System.Collections, Version=1.5.63.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.63\lib\nanoFramework.System.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Text, Version=1.3.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.3.29\lib\nanoFramework.System.Text.dll</HintPath>
+    <Reference Include="nanoFramework.System.Text, Version=1.3.36.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.3.36\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Streams, Version=1.1.89.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.89\lib\System.IO.Streams.dll</HintPath>
+    <Reference Include="System.IO.Streams, Version=1.1.91.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.91\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net, Version=1.11.34.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.34\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.11.37.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.37\lib\System.Net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Threading, Version=1.1.49.41415, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.49\lib\System.Threading.dll</HintPath>
+    <Reference Include="System.Threading, Version=1.1.50.48563, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.50\lib\System.Threading.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/MakoIoT.Device.Services.Mqtt/packages.config
+++ b/src/MakoIoT.Device.Services.Mqtt/packages.config
@@ -2,15 +2,15 @@
 <packages>
   <package id="MakoIoT.Device.Services.Interface" version="1.0.53.21413" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.40.2867" targetFramework="netnano1.0" />
-  <package id="nanoFramework.CoreLibrary" version="1.17.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.DependencyInjection" version="1.1.29" targetFramework="netnano1.0" />
-  <package id="nanoFramework.M2Mqtt" version="5.1.187" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Runtime.Events" version="1.11.30" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Runtime.Native" version="1.7.9" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Collections" version="1.5.62" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.IO.Streams" version="1.1.89" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.11.34" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Text" version="1.3.29" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Threading" version="1.1.49" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.17.7" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.DependencyInjection" version="1.1.30" targetFramework="netnano1.0" />
+  <package id="nanoFramework.M2Mqtt" version="5.1.192" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.31" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Native" version="1.7.10" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Collections" version="1.5.63" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.91" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.11.37" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.3.36" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Threading" version="1.1.50" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.7.115" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps nanoFramework.CoreLibrary from 1.17.1 to 1.17.7</br>Bumps nanoFramework.DependencyInjection from 1.1.29 to 1.1.30</br>Bumps nanoFramework.M2Mqtt from 5.1.187 to 5.1.192</br>Bumps nanoFramework.Runtime.Events from 1.11.30 to 1.11.31</br>Bumps nanoFramework.Runtime.Native from 1.7.9 to 1.7.10</br>Bumps nanoFramework.System.Collections from 1.5.62 to 1.5.63</br>Bumps nanoFramework.System.IO.Streams from 1.1.89 to 1.1.91</br>Bumps nanoFramework.System.Net from 1.11.34 to 1.11.37</br>Bumps nanoFramework.System.Text from 1.3.29 to 1.3.36</br>Bumps nanoFramework.System.Threading from 1.1.49 to 1.1.50</br>
[version update]

### :warning: This is an automated update. :warning:
