### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.Mqtt.nuspec
+++ b/MakoIoT.Device.Services.Mqtt.nuspec
@@ -21,7 +21,7 @@
       <dependency id="MakoIoT.Device.Utilities.String" version="1.0.43.34490" />
       <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
-      <dependency id="nanoFramework.M2Mqtt" version="5.1.196" />
+      <dependency id="nanoFramework.M2Mqtt" version="5.1.199" />
       <dependency id="nanoFramework.Runtime.Events" version="1.11.32" />
       <dependency id="nanoFramework.Runtime.Native" version="1.7.11" />
       <dependency id="nanoFramework.System.Collections" version="1.5.67" />

--- a/src/MakoIoT.Device.Services.Mqtt/MakoIoT.Device.Services.Mqtt.nfproj
+++ b/src/MakoIoT.Device.Services.Mqtt/MakoIoT.Device.Services.Mqtt.nfproj
@@ -38,11 +38,11 @@
     <Reference Include="nanoFramework.DependencyInjection, Version=1.1.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.32\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.M2Mqtt, Version=5.1.196.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.196\lib\nanoFramework.M2Mqtt.dll</HintPath>
+    <Reference Include="nanoFramework.M2Mqtt, Version=5.1.199.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.199\lib\nanoFramework.M2Mqtt.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.M2Mqtt.Core, Version=5.1.196.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.196\lib\nanoFramework.M2Mqtt.Core.dll</HintPath>
+    <Reference Include="nanoFramework.M2Mqtt.Core, Version=5.1.199.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.M2Mqtt.5.1.199\lib\nanoFramework.M2Mqtt.Core.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.11.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.32\lib\nanoFramework.Runtime.Events.dll</HintPath>

--- a/src/MakoIoT.Device.Services.Mqtt/packages.config
+++ b/src/MakoIoT.Device.Services.Mqtt/packages.config
@@ -4,7 +4,7 @@
   <package id="MakoIoT.Device.Utilities.String" version="1.0.43.34490" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnanoframework10" />
   <package id="nanoFramework.DependencyInjection" version="1.1.32" targetFramework="netnano1.0" />
-  <package id="nanoFramework.M2Mqtt" version="5.1.196" targetFramework="netnano1.0" />
+  <package id="nanoFramework.M2Mqtt" version="5.1.199" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Native" version="1.7.11" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Collections" version="1.5.67" targetFramework="netnanoframework10" />


### PR DESCRIPTION
Bumps nanoFramework.M2Mqtt from 5.1.196 to 5.1.199</br>
[version update]

### :warning: This is an automated update. :warning:
